### PR TITLE
Addressing child element wording concern from issue #7

### DIFF
--- a/twine-2-htmloutput-spec.md
+++ b/twine-2-htmloutput-spec.md
@@ -63,7 +63,7 @@ Each passage is represented as a `<tw-passagedata>` element with its metadata st
 
 Passage content is stored within a text node of the `<tw-passagedata>` element itself; all `&`, `<`, `>`, `"`, and `'` characters should be escaped into their corresponding HTML entities.
 
-`<tw-passagedata>` should have no other child elements than a single text node.
+`<tw-passagedata>` should contain no child nodes other than the single text node for its content.
 
 **Example:**
 ```

--- a/twine-2-htmloutput-spec.md
+++ b/twine-2-htmloutput-spec.md
@@ -63,7 +63,7 @@ Each passage is represented as a `<tw-passagedata>` element with its metadata st
 
 Passage content is stored within a text node of the `<tw-passagedata>` element itself; all `&`, `<`, `>`, `"`, and `'` characters should be escaped into their corresponding HTML entities.
 
-`<tw-passagedata>` should have no other children elements than a single text node.
+`<tw-passagedata>` should have no other child elements than a single text node.
 
 **Example:**
 ```

--- a/twine-2-htmloutput-spec.md
+++ b/twine-2-htmloutput-spec.md
@@ -61,9 +61,9 @@ Each passage is represented as a `<tw-passagedata>` element with its metadata st
 * position: (string) Optional. Comma-separated X and Y position of the upper-left of the passage when viewed within the Twine 2 editor.
 * size: (string) Optional. Comma-separated width and height of the passage when viewed within the Twine 2 editor.
 
-Passage content is stored within the inner text of the `<tw-passagedata>` element itself; all `&`, `<`, `>`, `"`, and `'` characters should be escaped into their corresponding HTML entities.
+Passage content is stored within a text node of the `<tw-passagedata>` element itself; all `&`, `<`, `>`, `"`, and `'` characters should be escaped into their corresponding HTML entities.
 
-`<tw-passagedata>` should not have child elements.
+`<tw-passagedata>` should have no other children elements than a single text node.
 
 **Example:**
 ```

--- a/twine-2-htmloutput-spec.md
+++ b/twine-2-htmloutput-spec.md
@@ -61,9 +61,7 @@ Each passage is represented as a `<tw-passagedata>` element with its metadata st
 * position: (string) Optional. Comma-separated X and Y position of the upper-left of the passage when viewed within the Twine 2 editor.
 * size: (string) Optional. Comma-separated width and height of the passage when viewed within the Twine 2 editor.
 
-Passage content is stored within a text node of the `<tw-passagedata>` element itself; all `&`, `<`, `>`, `"`, and `'` characters should be escaped into their corresponding HTML entities.
-
-`<tw-passagedata>` should contain no child nodes other than the single text node for its content.
+Passage content is stored within the <tw-passagedata> element itself as a single text node and must contain no other child nodes; all &, <, >, ", and ' characters should be escaped into their corresponding HTML entities.
 
 **Example:**
 ```


### PR DESCRIPTION
Addressing potentially confusing wording from #7.

Change into specifically mentioning "text nodes" and that  `<tw-passagedata>` should have no other child elements than a single text node.