### PR TITLE
Added creator and creator-version; Markdown clean-up

### DIFF
--- a/twine-2-htmloutput-spec.md
+++ b/twine-2-htmloutput-spec.md
@@ -1,11 +1,12 @@
-# Twine 2 HTML Output (v1.0.0)
+# Twine 2 HTML Output (v1.0.1)
 
 Twine 2 stores its data within HTML elements.
 
 The root of a Twine 2 story is the `<tw-storydata>` element with attributes encoding metadata about the story itself. Inside of this element are the `<tw-passagedata>` (Passages), `<tw-tag>` (Passage Tag Colors), `<style>` (Story Stylesheet), and `<script>` (Story JavaScript) elements.
 
 **Example:**
-```
+
+```html
 <tw-storydata>
   <style
     role="stylesheet"
@@ -35,9 +36,12 @@ Story metadata is stored as attributes on the `<tw-storydata>` element.
 * format-version: (string) Optional. The version of the story format used to create the story.
 * startnode: (string) Optional. The PID matching a `<tw-passagedata>` element whose content should be displayed first.
 * zoom: (string) Optional. The decimal level of zoom (i.e. 1.0 is 100% and 1.2 would be 120% zoom level).
+* creator: (string) Optional. The name of program used to create the file.
+* creator-version: (string) Optional. The version of the program used to create the file.
 
 **Example:**
-```
+
+```html
 <tw-storydata
   name="DocumentationExample"
   startnode="1"
@@ -61,10 +65,11 @@ Each passage is represented as a `<tw-passagedata>` element with its metadata st
 * position: (string) Optional. Comma-separated X and Y position of the upper-left of the passage when viewed within the Twine 2 editor.
 * size: (string) Optional. Comma-separated width and height of the passage when viewed within the Twine 2 editor.
 
-Passage content is stored within the <tw-passagedata> element itself as a single text node and must contain no other child nodes; all &, <, >, ", and ' characters should be escaped into their corresponding HTML entities.
+Passage content is stored within the `<tw-passagedata>` element itself as a single text node and must contain no other child nodes; all &, <, >, ", and ' characters should be escaped into their corresponding HTML entities.
 
 **Example:**
-```
+
+```html
 <tw-passagedata
   pid="1"
   name="Start"
@@ -75,14 +80,15 @@ Some content
 </tw-passagedata>
 ```
 
-##  Story JavaScript
+## Story JavaScript
 
 Any JavaScript code saved from the Story JavaScript window of the Story menu in Twine 2 is kept within a single `<script>` element with its `type` attribute set to `text/twine-javascript`.
 
 This will be executed upon story start.
 
 **Example:**
-```
+
+```html
 <script id="twine-user-script" type="text/twine-javascript">window.setup = {};</script>
 ```
 
@@ -93,7 +99,8 @@ Any CSS rules saved from the Story Stylesheet window from the Story menu in Twin
 Any CSS rules found within the element will applied to the document upon story start.
 
 **Example:**
-```
+
+```html
 <style id="twine-user-stylesheet" type="text/twine-css">body {font-size: 1.5em;}</style>
 ```
 
@@ -102,6 +109,7 @@ Any CSS rules found within the element will applied to the document upon story s
 If any passage tags have been assigned colors within the Twine 2 editor, they will appear as `<tw-tag>` elements. The `name` attribute will be the name of the tag and the `color` attribute will be one of seven named colors.
 
 Named Colors:
+
 * `gray`
 * `red`
 * `orange`
@@ -111,7 +119,8 @@ Named Colors:
 * `purple`
 
 **Example:**
-```
+
+```html
 <tw-tag name="one" color="gray"></tw-tag>
 <tw-tag name="two" color="purple"></tw-tag>
 ```


### PR DESCRIPTION
Added creator and creator-version to Story Data in Twine 2 HTML Output file.

While editing, also added [language to all code blocks](https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md#md040---fenced-code-blocks-should-have-a-language-specified) and [added lines between code blocks](https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md#md031---fenced-code-blocks-should-be-surrounded-by-blank-lines) to match Markdown linting rules.