### PR TITLE
Add story tags attribute

### DIFF
--- a/twine-2-htmloutput-spec.md
+++ b/twine-2-htmloutput-spec.md
@@ -35,7 +35,7 @@ Story metadata is stored as attributes on the `<tw-storydata>` element.
 * format: (string) Optional. The story format used to create the story.
 * format-version: (string) Optional. The version of the story format used to create the story.
 * startnode: (string) Optional. The PID matching a `<tw-passagedata>` element whose content should be displayed first.
-* tags (string) Optional. A list of tags assigned to the story by its author, with spaces separating them.
+* tags: (string) Optional. A list of tags assigned to the story by its author, with spaces separating them.
 * zoom: (string) Optional. The decimal level of zoom (i.e. 1.0 is 100% and 1.2 would be 120% zoom level).
 * creator: (string) Optional. The name of program used to create the file.
 * creator-version: (string) Optional. The version of the program used to create the file.

--- a/twine-2-htmloutput-spec.md
+++ b/twine-2-htmloutput-spec.md
@@ -35,6 +35,7 @@ Story metadata is stored as attributes on the `<tw-storydata>` element.
 * format: (string) Optional. The story format used to create the story.
 * format-version: (string) Optional. The version of the story format used to create the story.
 * startnode: (string) Optional. The PID matching a `<tw-passagedata>` element whose content should be displayed first.
+* tags (string) Optional. A list of tags assigned to the story by its author, with spaces separating them.
 * zoom: (string) Optional. The decimal level of zoom (i.e. 1.0 is 100% and 1.2 would be 120% zoom level).
 * creator: (string) Optional. The name of program used to create the file.
 * creator-version: (string) Optional. The version of the program used to create the file.


### PR DESCRIPTION
This is a forthcoming change in Twine 2.4. An early form of this functionality has landed on [the develop branch](https://github.com/klembot/twinejs/tree/develop) if you'd like to take a look, but keep in mind that the code is in pre-alpha state and could easily trash any existing stories/cause weird issues if you downgrade to 2.3.