### PR TITLE
Twine 2 JSON

### DIFF
--- a/twine-2-jsonoutput-doc.md
+++ b/twine-2-jsonoutput-doc.md
@@ -2,11 +2,11 @@
 
 This specification defines a series of properties for encoding story and passage data compatible with Twine 2 and related tools using [JavaScript Object Notation (JSON)](https://www.json.org/json-en.html).
 
-## Story Encoding
+## Story Data Encoding
 
-To maintain close compatibility with the existing formats of [Twine 2 HTML](https://github.com/iftechfoundation/twine-specs/blob/master/twine-2-htmloutput-spec.md) and [Twee 3 notation](https://github.com/iftechfoundation/twine-specs/blob/master/twee-3-specification.md), story properties encoded in JSON mirror those found in the [`StoryData` passage in Twee 3 notation](https://github.com/iftechfoundation/twine-specs/blob/master/twee-3-specification.md#storydata):
+To maintain close compatibility with the existing output formats of [Twine 2 HTML](https://github.com/iftechfoundation/twine-specs/blob/master/twine-2-htmloutput-spec.md) and [Twee 3 notation](https://github.com/iftechfoundation/twine-specs/blob/master/twee-3-specification.md), story properties encoded in JSON mirror those found in the [`StoryData` passage in Twee 3 notation](https://github.com/iftechfoundation/twine-specs/blob/master/twee-3-specification.md#storydata):
 
-- `ifid`: (string) Required. Maps to `<tw-storydata ifid>`.
+- `ifid`: (string) Optional. Maps to `<tw-storydata ifid>`.
 - `format`: (string) Optional. Maps to `<tw-storydata format>`.
 - `format-version`: (string) Optional. Maps to `<tw-storydata format-version>`.
 - `start`: (string) Optional. Maps to `<tw-passagedata name>` of the node whose pid matches `<tw-storydata startnode>`.
@@ -34,13 +34,13 @@ To maintain close compatibility with the existing formats of [Twine 2 HTML](http
         "position":"600,400",
         "size":"100,200"
       },
-      "content": "Double-click this passage to edit it."
+      "text": "Double-click this passage to edit it."
     }
   ]
 }
 ```
 
-## Passage Encoding
+## Passage Data Encoding
 
 Passage properties mirror those found in Twee 3 notation:
 
@@ -49,7 +49,7 @@ Passage properties mirror those found in Twee 3 notation:
 - `metadata`: (object of name(string):value(string) pairs). Optional. As in Twee 3 notation, a passage can contain multiple name-value pairs. For compatibility with Twine 2, the currently supported properties include:
   - `position`: (string) Comma separated passage tile positional coordinates (e.g., "600,400").
   - `size`: (string) Comma separated passage tile width and height (e.g., "100,200").
-- `content`: (string) Required. Content of the passage.
+- `text`: (string) Required. Content of the passage.
 
 ```json
 {
@@ -59,6 +59,12 @@ Passage properties mirror those found in Twee 3 notation:
     "position":"600,400",
     "size":"100,200"
   },
-  "content": "Double-click this passage to edit it."
+  "text": "Double-click this passage to edit it."
 }
 ```
+
+## Optional Partial Story Encoding
+
+Using JSON representation, a story can be encoded in whole or in part. When directly converting from one output format to another, story metadata is suggested but optional.
+
+Because `passages` is the only required story metadata property, a selection of content, named "partial story encoding," is possible to represent a subset of passages and story metadata. Depending on the story format, this allows for representing in JSON additional story content, CSS, or JavaScript for including as part of a larger story compilation process.

--- a/twine-2-jsonoutput-doc.md
+++ b/twine-2-jsonoutput-doc.md
@@ -28,12 +28,13 @@ To maintain close compatibility with the existing formats of [Twine 2 HTML](http
   "zoom": 0.25,
   "passages": [
     {
-      "name": "My Staring Passage",
+      "name": "My Starting Passage",
       "tags": ["tag1", "tag2"],
       "metadata": {
         "position":"600,400",
         "size":"100,200"
-      }
+      },
+      "content": "Double-click this passage to edit it."
     }
   ]
 }
@@ -48,14 +49,16 @@ Passage properties mirror those found in Twee 3 notation:
 - `metadata`: (object of name(string):value(string) pairs). Optional. As in Twee 3 notation, a passage can contain multiple name-value pairs. For compatibility with Twine 2, the currently supported properties include:
   - `position`: (string) Comma separated passage tile positional coordinates (e.g., "600,400").
   - `size`: (string) Comma separated passage tile width and height (e.g., "100,200").
+- `content`: (string) Required. Content of the passage.
 
 ```json
 {
-  "name": "My Staring Passage",
+  "name": "My Starting Passage",
   "tags": ["tag1", "tag2"],
   "metadata": {
     "position":"600,400",
     "size":"100,200"
-  }
+  },
+  "content": "Double-click this passage to edit it."
 }
 ```

--- a/twine-2-jsonoutput-doc.md
+++ b/twine-2-jsonoutput-doc.md
@@ -15,6 +15,8 @@ To maintain compatibility with the existing output formats of [Twine 2 HTML](htt
 - `zoom`: (decimal) Optional. Maps to `<tw-storydata zoom>`.
 - `creator`: (string) Optional. The name of program used to create the file. Maps to `<tw-storydata creator>`.
 - `creator-version`: (string) Optional. The version of the program used to create the file. Maps to `<tw-storydata creator-version>`.
+- `style`: (string) Optional. Story Stylesheet content. Maps to `<style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css"></style>`.
+- `script`: (string) Optional. Story JavaScript content. Maps to `<script role="script" id="twine-user-script" type="text/twine-javascript"></script>`.
 - `passages`: (array of objects) Required. Array of one or more passage objects encoded in JSON.
 
 ```json
@@ -32,6 +34,8 @@ To maintain compatibility with the existing output formats of [Twine 2 HTML](htt
   "zoom": 0.25,
   "creator": "Twine",
   "creator-version": "2.8",
+  "style": "",
+  "script": "",
   "passages": [
     {
       "name": "My Starting Passage",

--- a/twine-2-jsonoutput-doc.md
+++ b/twine-2-jsonoutput-doc.md
@@ -1,0 +1,61 @@
+# Twine 2 JSON Specification (v1.0)
+
+This specification defines a series of properties for encoding story and passage data compatible with Twine 2 and related tools using [JavaScript Object Notation (JSON)](https://www.json.org/json-en.html).
+
+## Story Encoding
+
+To maintain close compatibility with the existing formats of [Twine 2 HTML](https://github.com/iftechfoundation/twine-specs/blob/master/twine-2-htmloutput-spec.md) and [Twee 3 notation](https://github.com/iftechfoundation/twine-specs/blob/master/twee-3-specification.md), story properties encoded in JSON mirror those found in the [`StoryData` passage in Twee 3 notation](https://github.com/iftechfoundation/twine-specs/blob/master/twee-3-specification.md#storydata):
+
+- `ifid`: (string) Required. Maps to `<tw-storydata ifid>`.
+- `format`: (string) Optional. Maps to `<tw-storydata format>`.
+- `format-version`: (string) Optional. Maps to `<tw-storydata format-version>`.
+- `start`: (string) Optional. Maps to `<tw-passagedata name>` of the node whose pid matches `<tw-storydata startnode>`.
+- `tag-colors`: (object of tag(string):color(string) pairs) Optional. Pairs map to `<tw-tag>` nodes as `<tw-tag name>:<tw-tag color>`.
+- `zoom`: (decimal) Optional. Maps to `<tw-storydata zoom>`.
+- `passages`: (array of objects) Required. Array of one or more passage objects encoded in JSON.
+
+```json
+{
+  "ifid": "D674C58C-DEFA-4F70-B7A2-27742230C0FC",
+  "format": "Snowman",
+  "format-version": "3.0.2",
+  "start": "My Starting Passage",
+  "tag-colors": {
+    "bar": "green",
+    "foo": "red",
+    "qaz": "blue"
+  },
+  "zoom": 0.25,
+  "passages": [
+    {
+      "name": "My Staring Passage",
+      "tags": ["tag1", "tag2"],
+      "metadata": {
+        "position":"600,400",
+        "size":"100,200"
+      }
+    }
+  ]
+}
+```
+
+## Passage Encoding
+
+Passage properties mirror those found in Twee 3 notation:
+
+- `name`: (string) Required. Name of the passage.
+- `tags`: (array of tag(string) ) Required. An Array of tags as string values.
+- `metadata`: (object of name(string):value(string) pairs). Optional. As in Twee 3 notation, a passage can contain multiple name-value pairs. For compatibility with Twine 2, the currently supported properties include:
+  - `position`: (string) Comma separated passage tile positional coordinates (e.g., "600,400").
+  - `size`: (string) Comma separated passage tile width and height (e.g., "100,200").
+
+```json
+{
+  "name": "My Staring Passage",
+  "tags": ["tag1", "tag2"],
+  "metadata": {
+    "position":"600,400",
+    "size":"100,200"
+  }
+}
+```

--- a/twine-2-jsonoutput-doc.md
+++ b/twine-2-jsonoutput-doc.md
@@ -4,28 +4,34 @@ This specification defines a series of properties for encoding story and passage
 
 ## Story Data Encoding
 
-To maintain close compatibility with the existing output formats of [Twine 2 HTML](https://github.com/iftechfoundation/twine-specs/blob/master/twine-2-htmloutput-spec.md) and [Twee 3 notation](https://github.com/iftechfoundation/twine-specs/blob/master/twee-3-specification.md), story properties encoded in JSON mirror those found in the [`StoryData` passage in Twee 3 notation](https://github.com/iftechfoundation/twine-specs/blob/master/twee-3-specification.md#storydata):
+To maintain compatibility with the existing output formats of [Twine 2 HTML](https://github.com/iftechfoundation/twine-specs/blob/master/twine-2-htmloutput-spec.md) and [Twee 3 notation](https://github.com/iftechfoundation/twine-specs/blob/master/twee-3-specification.md), story properties encoded in JSON mirror those found in the [`StoryData` passage in Twee 3 notation](https://github.com/iftechfoundation/twine-specs/blob/master/twee-3-specification.md#storydata):
 
-- `ifid`: (string) Optional. Maps to `<tw-storydata ifid>`.
-- `format`: (string) Optional. Maps to `<tw-storydata format>`.
-- `format-version`: (string) Optional. Maps to `<tw-storydata format-version>`.
-- `start`: (string) Optional. Maps to `<tw-passagedata name>` of the node whose pid matches `<tw-storydata startnode>`.
+- `name`: (string) Required. The name of the story. Maps to `<tw-storydata name>`.
+- `ifid`: (string) Optional. An IFID is a sequence of between 8 and 63 characters, each of which shall be a digit, a capital letter or a hyphen that uniquely identify a story (see [Treaty of Babel](https://babel.ifarchive.org/)). Maps to `<tw-storydata ifid>`.
+- `format`: (string) Optional. The name of the story format used to create the story. Maps to `<tw-storydata format>`.
+- `format-version`: (string) Optional. The version of the story format used to create the story. Maps to `<tw-storydata format-version>`.
+- `start`: (string) Optional. The PID matching a `<tw-passagedata>` element whose content should be displayed first. Maps to `<tw-storydata startnode>`.
 - `tag-colors`: (object of tag(string):color(string) pairs) Optional. Pairs map to `<tw-tag>` nodes as `<tw-tag name>:<tw-tag color>`.
 - `zoom`: (decimal) Optional. Maps to `<tw-storydata zoom>`.
+- `creator`: (string) Optional. The name of program used to create the file. Maps to `<tw-storydata creator>`.
+- `creator-version`: (string) Optional. The version of the program used to create the file. Maps to `<tw-storydata creator-version>`.
 - `passages`: (array of objects) Required. Array of one or more passage objects encoded in JSON.
 
 ```json
 {
+  "name": "Example",
   "ifid": "D674C58C-DEFA-4F70-B7A2-27742230C0FC",
   "format": "Snowman",
   "format-version": "3.0.2",
   "start": "My Starting Passage",
   "tag-colors": {
-    "bar": "green",
+    "bar": "Green",
     "foo": "red",
     "qaz": "blue"
   },
   "zoom": 0.25,
+  "creator": "Twine",
+  "creator-version": "2.8",
   "passages": [
     {
       "name": "My Starting Passage",
@@ -67,4 +73,4 @@ Passage properties mirror those found in Twee 3 notation:
 
 Using JSON representation, a story can be encoded in whole or in part. When directly converting from one output format to another, story metadata is suggested but optional.
 
-Because `passages` is the only required story metadata property, a selection of content, named "partial story encoding," is possible to represent a subset of passages and story metadata. Depending on the story format, this allows for representing in JSON additional story content, CSS, or JavaScript for including as part of a larger story compilation process.
+Because `name` and `passages` are the only required story metadata properties, a selection of content, named "partial story encoding," is possible to represent a subset of passages and story metadata. Depending on the story format, this allows for representing in JSON additional story content, CSS, or JavaScript for including as part of a larger story compilation process.


### PR DESCRIPTION
I don't love the idea of adding even more formats (Twine 1: TWS, HTML, Twee; Twine 2: Archive, HTML, Twee), but it does feel like this might be needed at some point, if for no other reason than to define it more officially.